### PR TITLE
[wip] wrap errors in middleware

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -100,21 +100,30 @@ function promisifyServer(server) {
     return fn.call(this, name, function (req, cb) {
       wrappedHandler.call(this, req)
         .then(function (res) { cb(undefined, res); })
-        .catch(function (err) {
-          if (
-            err && typeof err.wrapped == 'function' &&
-            msg.errorType.typeName === 'union:wrapped'
-          ) {
-            // Allow handlers to throw custom error instances directly even
-            // when the message's error type is a wrapped union.
-            cb(err.wrapped());
-          } else {
-            cb(err);
-          }
-        });
+        .catch(function (err) { cb(formatError(msg, err)); });
     });
   };
   return server;
+}
+
+/**
+ * Takes any object and wraps it if it should be wrapped
+ *
+ * This allow handlers to throw custom error instances directly even
+ * when the message's error type is a wrapped union.
+ *
+ * @param {Object} msg - schema for msg the error generated for
+ * @param {*} err - object to check
+ */
+function formatError(msg, err) {
+  const shouldWrap = err && typeof err.wrapped == 'function'
+                  && msg.errorType.typeName === 'union:wrapped';
+
+  if (shouldWrap) {
+    return err.wrapped();
+  }
+
+  return err;
 }
 
 /**
@@ -135,6 +144,8 @@ function promisifyMiddleware(clientOrServer) {
   return clientOrServer;
 
   function promisifyHandler(handler) {
+    const wrappedHandler = Promise.method(handler);
+    const msg = this.message;
     return function (wreq, wres, next) {
       let reject, resolve, prev;
       const promise = new Promise(function (resolve_, reject_) {
@@ -143,7 +154,10 @@ function promisifyMiddleware(clientOrServer) {
       });
       let ret;
       try {
-        ret = handler.call(this, wreq, wres, (err, cb) => {
+        ret = wrappedHandler.call(this, wreq, wres, (err, cb) => {
+          if (err) {
+            err = formatError(msg, err)
+          }
           if (cb) {
             // Always use the callback API if one is provided here.
             next(err, cb);
@@ -162,9 +176,14 @@ function promisifyMiddleware(clientOrServer) {
       } catch (err) {
         // If an error is thrown synchronously in the handler, we'll be
         // accommodating and assume that this is a promise's rejection.
-        next(err);
+        next(formatError(msg, err));
         return;
       }
+
+      if (wres.error) {
+        wres.error = formatError(msg, wres.error);
+      }
+
       if (ret && typeof ret.then === 'function') {
         // Cheap way of testing whether `ret` is a promise. If so, we use the
         // promise-based API: we wait until the returned promise is complete to
@@ -176,7 +195,7 @@ function promisifyMiddleware(clientOrServer) {
 
       function done(err) {
         if (prev) {
-          prev(err);
+          prev(formatError(msg, err));
         } else {
           // This will happen if the returned promise is complete before the
           // one returned by `next()` is. There is no clear ideal behavior


### PR DESCRIPTION
Modify the middleware promisify method to allow middleware to behave the same as message handlers. 

Note: Still a work in progress